### PR TITLE
feat: Replace vm on tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ KUBECONFIG=/path/to/kubeconfig.yaml terraform apply -destroy -var-file=env.tfvar
 | <a name="provider_cloudinit"></a> [cloudinit](#provider\_cloudinit) | 2.3.5 |
 | <a name="provider_harvester"></a> [harvester](#provider\_harvester) | 0.6.4 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.6.3 |
+| <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules
 
@@ -93,6 +94,7 @@ No modules.
 | [harvester_cloudinit_secret.cloud-config](https://registry.terraform.io/providers/harvester/harvester/0.6.4/docs/resources/cloudinit_secret) | resource |
 | [harvester_virtualmachine.vm](https://registry.terraform.io/providers/harvester/harvester/0.6.4/docs/resources/virtualmachine) | resource |
 | [random_id.secret](https://registry.terraform.io/providers/hashicorp/random/3.6.3/docs/resources/id) | resource |
+| [terraform_data.vm_tags](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [cloudinit_config.server_user_data](https://registry.terraform.io/providers/hashicorp/cloudinit/2.3.5/docs/data-sources/config) | data source |
 | [harvester_image.img](https://registry.terraform.io/providers/harvester/harvester/0.6.4/docs/data-sources/image) | data source |
 | [harvester_ssh_key.mysshkey](https://registry.terraform.io/providers/harvester/harvester/0.6.4/docs/data-sources/ssh_key) | data source |

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,7 @@
+resource "terraform_data" "vm_tags" {
+  input = yamldecode(file("${path.module}/mkdocs-repo-reference.yaml"))
+}
+
 data "harvester_image" "img" {
   display_name = var.img_display_name
   namespace    = "harvester-public"
@@ -95,6 +99,12 @@ resource "harvester_virtualmachine" "vm" {
     network_data = templatefile("${path.module}/network-data.tmpl.yml", {
       network = var.network
     })
+  }
+
+  tags = terraform_data.vm_tags.output
+
+  lifecycle {
+    replace_triggered_by = [terraform_data.vm_tags]
   }
 
 }

--- a/mkdocs-repo-reference.yaml
+++ b/mkdocs-repo-reference.yaml
@@ -1,2 +1,2 @@
 # renovate: datasource=github-tags depName=UCL-ARC/condenser-mkdocs versioning=loose
-condenser-mkdocs_version: 0.0.0
+docs_version: 0.0.0


### PR DESCRIPTION
Includes the version of the documentation as a tag on the VM which lets terraform know that the VM should be replaced when the documentation changes. Renovate is responsible for automating these updates.